### PR TITLE
Adding Dockerfile to run examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM jupyter/minimal-notebook:ubuntu-20.04
+
+# docker build -t ideas-uo .
+
+# The base image has changed the active user to jovyan
+USER root
+RUN apt-get update && apt-get install -y libmysqlclient-dev gcc
+
+# Install ideas-uo
+WORKDIR /home/jovyan/work
+COPY . /home/jovyan/work
+RUN pip install -r requirements.txt && pip install -e . && chown -R jovyan .
+
+# Return to original notebook user
+USER jovyan

--- a/README.md
+++ b/README.md
@@ -13,17 +13,27 @@ short [book](https://www.pluralsight.com/content/dam/pluralsight2/landing-pages/
 by Plurasight on "20 patterns to watch for in your engineering team".
 
 ## Getting started
+
+### Install
+
+It is best to set up a new python3 environment first; complete instructions can be 
+found [here](https://docs.python.org/3/library/venv.html). 
+Once you have created and activated the environment, you can install prerequisites with 
+`pip install -r requirements.txt`.
+
+In order to access the database containing project information, you also need to have 
+a MySQL client library installed on your system before installing the requirements with `pip`. 
+This requires that you install the mysql client library on your system first. On
+Ubuntu 20.04, for example, you can accomplish this with `sudo apt install python3.9-dev libmysqlclient-dev`.
+
+### Notebooks
+
 You can take a look at the [notebooks](notebooks) to try out and learn what you can do with this tool. 
 Some of them have been made available through Google Colab, so you don't have to install anything to try them out.
 
 Note that this set of tools is still under very active development, so at any point 
 some functionality may not work as expected. The basic requirements are Python 3
 .9 or newer and the `pip` package manager.
-
-It is best to set up a new python3 environment first; complete instructions can be 
-found [here](https://docs.python.org/3/library/venv.html). 
-Once you have created and activated the environment, you can install prerequisites with 
-`pip install -r requirements.txt`.
 
 If you wish to run the notebooks locally, you need to have jupyter (`pip install jupyter`) 
 or jupyter-lab (`pip install jupyterlab`), 
@@ -34,12 +44,33 @@ locally, use the `pip install -e .` command in the top-level project directory.
 Then you can run `jupyter-lab` or `jupyter`
 in the `ideas-uo` directory. You can also open a specific notebook, 
 e.g., `jupyter-lab notebooks/PatternsTest.ipynb`
- 
-In order to access the database containing project information, you also need to have 
-a MySQL client library installed on your system before installing the requirements with `pip`. 
-This requires that you install the mysql client library on your system first. On
-Ubuntu 20.04, for example, you can accomplish this with `sudo apt install python3.9-dev libmysqlclient-dev`.
 
+### Container
+
+If you want to get started with using the software without modifying your system,
+you can use the provided [Dockerfile](Dockerfile) to build a base container with
+all dependencies installed. 
+
+```bash
+$ docker build -t ideas-uo .
+```
+
+The contents of the repository here (meaning the notebook examples) will be copied
+to the active user's work directory (/home/joyvan/work) so you can run the container
+without needing to bind content locally:
+
+```bash
+$ docker run --rm -p 8888:8888 ideas-uo
+```
+
+When you run the command above, a link will be pasted in the terminal (with a token included)
+that you can copy paste into your browser to see the interface. If you want
+to instead bind the present working notebooks directory (and files you can make changes to
+that will persist) you can instead run the container as follows:
+
+```bash
+$ docker run --rm -p 8888:8888 -v "${PWD}/notebooks":/home/jovyan/work/notebooks ideas-uo
+```
 
 ## Testing
 

--- a/src/patterns/fetcher.py
+++ b/src/patterns/fetcher.py
@@ -23,13 +23,13 @@ class Fetcher:
         self.exclude_forks = exclude_forks # Only work with non-forks of the repo
         self.forks_only = forks_only  # when True, only analyze forked repos
         self.top_dir = abspath(dirname(dirname(dirname(__file__))))
+        self.create_cache()
 
     def find_cache(self):
         for root, dirnames, filenames in os.walk(self.top_dir):
             filenames = [f for f in filenames if f == '.%s.pickle' % self.project]
             for filename in filenames:
                 return os.path.join(root, filename)
-        return None
 
     def fetch(self, db=None, cache=True, dbpwd=None):
         if cache:
@@ -109,10 +109,15 @@ class Fetcher:
         print(info_msg)
         return True
 
+    def create_cache(self):
+        if not os.path.exists(self.cache_dir): os.mkdir(self.cache_dir)
+
+    @property
+    def cache_dir(self):
+        return os.path.join(self.top_dir,'.db-cache')
+
     def update_cache(self):
-        cache_dir = os.path.join(self.top_dir,'.db-cache')
-        if not os.path.exists(cache_dir): os.mkdir(cache_dir)
-        self.commit_data.to_pickle(os.path.join(cache_dir, '.%s.pickle' % self.project))
+        self.commit_data.to_pickle(os.path.join(self.cache_dir, '.%s.pickle' % self.project))
 
     def close_session(self):
         if self.cursor:


### PR DESCRIPTION
This PR adds a Dockerfile that a developer/user can build to quickly interact with examples. The container includes a jupyter-minimal notebook with database and python dependencies for the project. Note that it looks like I need a database password to run most examples so I didn't test them all the way through. I also tweaked the README to include instructions to build and run the container, and re-organized the getting started a bit so there are clear sections for install, notebooks, and the container.

This will close #5

Signed-off-by: vsoch <vsoch@users.noreply.github.com>